### PR TITLE
Add composer installer and add package type as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,16 @@
 {
   "name": "humanmade/publishing-checklist",
   "description": "Publishing Checklist",
+  "type": "wordpress-plugin",
   "authors": [
     {
       "name": "Human Made",
       "email": "hello@hmn.md"
     }
   ],
+  "require": {
+    "composer/installers": "~1.0"
+  },
   "require-dev": {
     "wp-coding-standards/wpcs": "dev-develop"
   },


### PR DESCRIPTION
So for installing this plugin via composer we need `"composer/installers": "~1.0"`, so just adding the dependency 